### PR TITLE
Script now compress rest-server folder ignoring node_modules

### DIFF
--- a/chaincode/go.mod
+++ b/chaincode/go.mod
@@ -1,6 +1,6 @@
 module github.com/goledgerdev/cc-tools-demo/chaincode
 
-go 1.14
+go 1.13
 
 // replace github.com/goledgerdev/cc-tools => ../../cc-tools
 

--- a/chaincode/go.sum
+++ b/chaincode/go.sum
@@ -72,12 +72,6 @@ github.com/golang/protobuf v1.4.1/go.mod h1:U8fpvMrcmy5pZrNK1lt4xCsGvpyWQ/VVv6QD
 github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/protobuf v1.4.3 h1:JjCZWpVbqXDqFVmTfYWEVTMIYrL/NPdPSCHPJ0T/raM=
 github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
-github.com/goledgerdev/cc-tools v0.7.1-0.20210714205451-240541ab9436 h1:H0/+cbj7BJZG0xHBjeHNJq/xPIkIcurSTGlYoBsh0D0=
-github.com/goledgerdev/cc-tools v0.7.1-0.20210714205451-240541ab9436/go.mod h1:A69loyqfqGyX0TYd4aBZyDGwvXUQ5MajnJ9wBhmPkJM=
-github.com/goledgerdev/cc-tools v0.7.1-0.20210728190509-72b577c214d0 h1:gzC3XxV70HtW9LVNl/1s1eBp+SaXT8P5kZEiV1e7tjE=
-github.com/goledgerdev/cc-tools v0.7.1-0.20210728190509-72b577c214d0/go.mod h1:A69loyqfqGyX0TYd4aBZyDGwvXUQ5MajnJ9wBhmPkJM=
-github.com/goledgerdev/cc-tools v0.7.1-rc.1 h1:sBQrFKbUOC/ftO36ettQH62EabaxNTqc11+BU1PwNMM=
-github.com/goledgerdev/cc-tools v0.7.1-rc.1/go.mod h1:A69loyqfqGyX0TYd4aBZyDGwvXUQ5MajnJ9wBhmPkJM=
 github.com/goledgerdev/cc-tools v0.7.1 h1:4xgAiZcEDA1LBTEs441C53gJ9NfLv0r+pNQULedjV4s=
 github.com/goledgerdev/cc-tools v0.7.1/go.mod h1:A69loyqfqGyX0TYd4aBZyDGwvXUQ5MajnJ9wBhmPkJM=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=

--- a/generateTar.sh
+++ b/generateTar.sh
@@ -3,8 +3,8 @@
 # Make sure go mod is up to date
 cd chaincode && go mod vendor && cd ..
 
-# Clean rest-server folder
-# cd rest-server && sudo rm -rf node_modules dist && cd ..
-
-# Zip file
+# Compress file without rest-server (GoFabric will use the standard CC API)
 tar -czf cc-tools-demo.tar.gz chaincode
+
+# Compress file with rest-server (GoFabric will use the one provided)
+# tar -czf --exclude=node_modules cc-tools-demo.tar.gz chaincode rest-server

--- a/generateTemplateTar.sh
+++ b/generateTemplateTar.sh
@@ -37,7 +37,7 @@ rm chaincode/collections.json
 rm chaincode/header/header.go
 
 # Compress file
-tar -czf cc-tools-demo.tar.gz chaincode
+tar --exclude=node_modules -czf cc-tools-demo.tar.gz chaincode rest-server
 
 # Restore customAssets.go file
 printf "%s\n" "$CUSTOMASSETSFILE" > chaincode/assettypes/customAssets.go

--- a/generateTemplateTar.sh
+++ b/generateTemplateTar.sh
@@ -1,48 +1,21 @@
 #!/usr/bin/env bash
 
-function trap_ctrlc ()
-{
-    if [[ ! -z "$CUSTOMASSETSFILE" ]]
-    then
-        printf "%s\n" "$CUSTOMASSETSFILE" > chaincode/assettypes/customAssets.go
-    fi
-
-    if [[ ! -z "$COLLECTIONSFILE" ]]
-    then
-        printf "%s\n" "$COLLECTIONSFILE" > chaincode/collections.json
-    fi
-
-    if [[ ! -z "$HEADERFILE" ]]
-    then
-        printf "%s\n" "$HEADERFILE" > chaincode/header/header.go
-    fi
-
-    exit 2
-}
-
 # Make sure go mod is up to date
 cd chaincode && go mod vendor && cd ..
 
-# Copy customAssets.go content
-CUSTOMASSETSFILE=$(cat chaincode/assettypes/customAssets.go)
-COLLECTIONSFILE=$(cat chaincode/collections.json)
-HEADERFILE=$(cat chaincode/header/header.go)
+# Compress file without rest-server
+# GoFabric will use the standard CC API from Docker Hub
+tar \
+--exclude=chaincode/assettypes/customAssets.go \
+--exclude=chaincode/collections.json \
+--exclude=chaincode/header/header.go \
+-czf cc-tools-demo.tar.gz chaincode
 
-# Prevent loss of the customAssets.go file
-trap "trap_ctrlc" 2
-
-# Delete customAssets.go from tree before compressing
-rm chaincode/assettypes/customAssets.go
-rm chaincode/collections.json
-rm chaincode/header/header.go
-
-# Compress file
-tar --exclude=node_modules -czf cc-tools-demo.tar.gz chaincode rest-server
-
-# Restore customAssets.go file
-printf "%s\n" "$CUSTOMASSETSFILE" > chaincode/assettypes/customAssets.go
-printf "%s\n" "$COLLECTIONSFILE" > chaincode/collections.json
-printf "%s\n" "$HEADERFILE" > chaincode/header/header.go
-
-# Clear trap
-trap - 2
+# Compress file with rest-server
+# GoFabric will use the one provided
+# tar \
+# --exclude=node_modules \
+# --exclude=chaincode/assettypes/customAssets.go \
+# --exclude=chaincode/collections.json \
+# --exclude=chaincode/header/header.go \
+# -czf cc-tools-demo.tar.gz chaincode rest-server


### PR DESCRIPTION
This makes it unnecessary to compress the rest-server folder manually and then delete node_modules.