### PR TITLE
Remove pseudo TTY from docker exec command

### DIFF
--- a/fabric/scripts/generateCerts.sh
+++ b/fabric/scripts/generateCerts.sh
@@ -16,7 +16,7 @@ generateCerts() {
     for ORG in ${orgs[@]}; do
         ca="ca.$ORG"
 
-        docker exec -it $ca bash "${SCRIPTS_FOLDER}/generateOrgCerts.sh"
+        docker exec -i $ca bash "${SCRIPTS_FOLDER}/generateOrgCerts.sh"
         retVal=$?
         if [[ $? -ne 0 ]]; then
             return $?


### PR DESCRIPTION
I was having issues while trying to execute `startDev.sh` from a go program (I'm using a chaincode as a submodule), since golang binaries are not TTY. CAs were not being created. This little change should fix that, and the script still works in terminal.