### PR TITLE
Remove experimentalWorkspaceModule setting from gopls

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,8 +2,5 @@
     "go.testFlags": [
         "-v",
         "-coverpkg=github.com/goledgerdev/cc-tools-demo/chaincode/..."
-    ],
-    "gopls": {
-        "experimentalWorkspaceModule": true
-    }
+    ]
 }


### PR DESCRIPTION
The `experimentalWorkspaceModule` setting of `gopls` will be marked as DEPRECATED in the future and VS Code has been warning us every time we open a project with this setting. It's kinda annoying ^^'