### PR TITLE
Refactor scripts to use docker compose v2 commands

### DIFF
--- a/fabric/addOrg3/addOrg3.sh
+++ b/fabric/addOrg3/addOrg3.sh
@@ -87,7 +87,7 @@ function generateOrg3() {
 
     infoln "Generating certificates using Fabric CA"
 
-    IMAGE_TAG=${CA_IMAGETAG} docker-compose -f $COMPOSE_FILE_CA_ORG3 up -d 2>&1
+    IMAGE_TAG=${CA_IMAGETAG} $DOCKER_COMPOSE_CMD -f $COMPOSE_FILE_CA_ORG3 up -d 2>&1
 
     . fabric-ca/registerEnroll.sh
 
@@ -122,9 +122,9 @@ function generateOrg3Definition() {
 function Org3Up () {
   # start org3 nodes
   if [ "${DATABASE}" == "couchdb" ]; then
-    IMAGE_TAG=${IMAGETAG} docker-compose -f $COMPOSE_FILE_ORG3 -f $COMPOSE_FILE_COUCH_ORG3 up -d 2>&1
+    IMAGE_TAG=${IMAGETAG} $DOCKER_COMPOSE_CMD -f $COMPOSE_FILE_ORG3 -f $COMPOSE_FILE_COUCH_ORG3 up -d 2>&1
   else
-    IMAGE_TAG=$IMAGETAG docker-compose -f $COMPOSE_FILE_ORG3 up -d 2>&1
+    IMAGE_TAG=$IMAGETAG $DOCKER_COMPOSE_CMD -f $COMPOSE_FILE_ORG3 up -d 2>&1
   fi
   if [ $? -ne 0 ]; then
     fatalln "ERROR !!!! Unable to start Org3 network"
@@ -174,11 +174,11 @@ function networkDown () {
 OS_ARCH=$(echo "$(uname -s|tr '[:upper:]' '[:lower:]'|sed 's/mingw64_nt.*/windows/')-$(uname -m | sed 's/x86_64/amd64/g')" | awk '{print tolower($0)}')
 # timeout duration - the duration the CLI should wait for a response from
 # another container before giving up
-
+CLI_TIMEOUT=10
 # Using crpto vs CA. default is cryptogen
 CRYPTO="cryptogen"
-
-CLI_TIMEOUT=10
+# Docker compose command to be use on the script
+DOCKER_COMPOSE_CMD="docker compose"
 #default for delay
 CLI_DELAY=3
 # channel name defaults to "mychannel"
@@ -195,6 +195,18 @@ IMAGETAG="latest"
 CA_IMAGETAG="latest"
 # database
 DATABASE="leveldb"
+
+# Check docker compose version
+if docker compose &>/dev/null; then
+    DOCKER_COMPOSE_CMD="docker compose"
+else
+    if command -v docker-compose &>/dev/null; then
+        DOCKER_COMPOSE_CMD="docker-compose"
+    else
+        errorln "docker compose or docker-compose command not found. Please install the latest version of docker compose"
+        exit 1
+    fi
+fi
 
 # Parse commandline args
 

--- a/fabric/network.sh
+++ b/fabric/network.sh
@@ -427,7 +427,7 @@ function networkUp() {
     COMPOSE_FILES="${COMPOSE_FILES} -f ${COUCHDB_COMPOSE}"
   fi
 
-  IMAGE_TAG=$IMAGETAG docker-compose ${COMPOSE_FILES} up -d 2>&1
+  IMAGE_TAG=$IMAGETAG $DOCKER_COMPOSE_CMD ${COMPOSE_FILES} up -d 2>&1
 
   docker ps -a
   if [ $? -ne 0 ]; then
@@ -474,9 +474,9 @@ function deployCCAAS() {
 # Tear down running network
 function networkDown() {
   # stop org3 containers also in addition to org1 and org2, in case we were running sample to add org3
-  docker-compose -f $COMPOSE_FILE_BASE_ORG -f $COMPOSE_FILE_COUCH_ORG down --volumes --remove-orphans
-  docker-compose -f $COMPOSE_FILE_BASE -f $COMPOSE_FILE_COUCH -f $COMPOSE_FILE_CA down --volumes --remove-orphans
-  docker-compose -f $COMPOSE_FILE_COUCH_ORG3 -f $COMPOSE_FILE_ORG3 down --volumes --remove-orphans
+  $DOCKER_COMPOSE_CMD -f $COMPOSE_FILE_BASE_ORG -f $COMPOSE_FILE_COUCH_ORG down --volumes --remove-orphans
+  $DOCKER_COMPOSE_CMD -f $COMPOSE_FILE_BASE -f $COMPOSE_FILE_COUCH -f $COMPOSE_FILE_CA down --volumes --remove-orphans
+  $DOCKER_COMPOSE_CMD -f $COMPOSE_FILE_COUCH_ORG3 -f $COMPOSE_FILE_ORG3 down --volumes --remove-orphans
 
   # Don't remove the generated artifacts -- note, the ledgers are always removed
   if [ "$MODE" != "restart" ]; then
@@ -502,6 +502,8 @@ function networkDown() {
 # Obtain the OS and Architecture string that will be used to select the correct
 # native binaries for your platform, e.g., darwin-amd64 or linux-amd64
 OS_ARCH=$(echo "$(uname -s | tr '[:upper:]' '[:lower:]' | sed 's/mingw64_nt.*/windows/')-$(uname -m | sed 's/x86_64/amd64/g')" | awk '{print tolower($0)}')
+# Docker compose command to be use on the script
+DOCKER_COMPOSE_CMD="docker compose"
 # Using crpto vs CA. default is cryptogen
 CRYPTO="cryptogen"
 # timeout duration - the duration the CLI should wait for a response from
@@ -556,6 +558,18 @@ DATABASE="couchdb"
 ORG_QNTY=3
 # Clear containers (down mode) -- default = true
 CLR_CONTAINERS=true
+
+# Check docker compose version
+if docker compose &>/dev/null; then
+    DOCKER_COMPOSE_CMD="docker compose"
+else
+    if command -v docker-compose &>/dev/null; then
+        DOCKER_COMPOSE_CMD="docker-compose"
+    else
+        errorln "docker compose or docker-compose command not found. Please install the latest version of docker compose"
+        exit 1
+    fi
+fi
 
 # Parse commandline args
 

--- a/scripts/reloadCCAPI.sh
+++ b/scripts/reloadCCAPI.sh
@@ -3,6 +3,19 @@
 cd "$(dirname "$0")"
 
 ORG_QNTY=3
+DOCKER_COMPOSE_CMD="docker compose"
+
+# Check docker compose version
+if docker compose &>/dev/null; then
+    DOCKER_COMPOSE_CMD="docker compose"
+else
+    if command -v docker-compose &>/dev/null; then
+        DOCKER_COMPOSE_CMD="docker-compose"
+    else
+        errorln "docker compose or docker-compose command not found. Please install the latest version of docker compose"
+        exit 1
+    fi
+fi
 
 while getopts n: opt; do
     case $opt in
@@ -21,7 +34,7 @@ fi
 ## This brings up API in Go
 if [ $ORG_QNTY == 1 ]
 then
-    cd ../ccapi; docker-compose -f docker-compose-1org.yaml down; docker-compose -f docker-compose-1org.yaml up -d --build; cd ..
+    cd ../ccapi; $DOCKER_COMPOSE_CMD -f docker-compose-1org.yaml down; $DOCKER_COMPOSE_CMD -f docker-compose-1org.yaml up -d --build; cd ..
 else
-    cd ../ccapi; docker-compose down; docker-compose up -d --build; cd ..
+    cd ../ccapi; $DOCKER_COMPOSE_CMD down; $DOCKER_COMPOSE_CMD up -d --build; cd ..
 fi

--- a/startDev.sh
+++ b/startDev.sh
@@ -4,6 +4,19 @@ ORG_QNTY=3
 DEPLOY_CCAAS=false
 CCAAS_TLS_ENABLEd=""
 SKIP_COLL_GEN=false
+DOCKER_COMPOSE_CMD="docker compose"
+
+# Check docker compose version
+if docker compose &>/dev/null; then
+    DOCKER_COMPOSE_CMD="docker compose"
+else
+    if command -v docker-compose &>/dev/null; then
+        DOCKER_COMPOSE_CMD="docker-compose"
+    else
+        errorln "docker compose or docker-compose command not found. Please install the latest version of docker compose"
+        exit 1
+    fi
+fi
 
 while [[ $# -ge 1 ]] ; do
     key="$1"
@@ -58,7 +71,7 @@ cd ./fabric; ./startDev.sh -n $ORG_QNTY -ccaas $DEPLOY_CCAAS $CCAAS_TLS_ENABLED;
 ## This brings up API in Go
 if [ $ORG_QNTY == 1 ]
 then
-    cd ./ccapi; docker-compose -f docker-compose-1org.yaml up -d; cd ..
+    cd ./ccapi; $DOCKER_COMPOSE_CMD -f docker-compose-1org.yaml up -d; cd ..
 else
-    cd ./ccapi; docker-compose up -d; cd ..
+    cd ./ccapi; $DOCKER_COMPOSE_CMD up -d; cd ..
 fi

--- a/startWeb.sh
+++ b/startWeb.sh
@@ -1,3 +1,15 @@
 #!/usr/bin/env bash
 
-docker-compose -f ccapi/web-client/docker-compose-goinitus.yaml up -d
+DOCKER_COMPOSE_CMD="docker compose"
+if docker compose &>/dev/null; then
+    DOCKER_COMPOSE_CMD="docker compose"
+else
+    if command -v docker-compose &>/dev/null; then
+        DOCKER_COMPOSE_CMD="docker-compose"
+    else
+        errorln "docker compose or docker-compose command not found. Please install the latest version of docker compose"
+        exit 1
+    fi
+fi
+
+$DOCKER_COMPOSE_CMD -f ccapi/web-client/docker-compose-goinitus.yaml up -d


### PR DESCRIPTION
- Updated the startDev, startWeb, addOrg3.sh, network.sh and reloadCCAPI.sh scripts to use the compose v2 command when possible
- The script now verifies the docker compose command available in the system to decide which one to use it. It displays an error if none is found