### PR TITLE
Bump Fabric version to 2.5.16

### DIFF
--- a/ccapi/chaincode/utils.go
+++ b/ccapi/chaincode/utils.go
@@ -22,5 +22,9 @@ func extractStatusCode(msg string) int {
 		return http.StatusInternalServerError
 	}
 
+	if statusCode < 100 || statusCode > 599 {
+		return http.StatusInternalServerError
+	}
+
 	return statusCode
 }

--- a/chaincode/tests/request_test.go
+++ b/chaincode/tests/request_test.go
@@ -103,7 +103,7 @@ func theResponseShouldHave(ctx context.Context, body *godog.DocString) error {
 		return err
 	}
 	if err := json.Unmarshal(respBody, &received); err != nil {
-		return err
+		return fmt.Errorf("failed to parse response body as JSON: %w\nActual response body: %s", err, string(respBody))
 	}
 
 	for key, value := range expected {
@@ -341,19 +341,33 @@ func InitializeScenario(ctx *godog.ScenarioContext) {
 
 func waitForNetwork(port string) error {
 	channel := make(chan error, 1)
-	t := time.NewTimer(3 * time.Minute)
+	t := time.NewTimer(5 * time.Minute)
 
 	defer t.Stop()
 
 	go func() {
+		// Phase 1: wait for the HTTP server to be up
 		for {
 			_, err := http.Post("http://localhost:"+port+"/api", "application/json", nil)
-
 			if err == nil {
 				break
 			}
-
 			time.Sleep(1 * time.Second)
+		}
+
+		// Phase 2: wait for the chaincode to be ready by polling a query endpoint
+		reqJSON, _ := json.Marshal(map[string]interface{}{"authorName": "_healthcheck_"})
+		b64str := b64.StdEncoding.EncodeToString(reqJSON)
+		for {
+			res, err := http.Get("http://localhost:" + port + "/api/query/getBooksByAuthor?@request=" + b64str)
+			if err == nil {
+				io.ReadAll(res.Body)
+				res.Body.Close()
+				if res.StatusCode == 200 {
+					break
+				}
+			}
+			time.Sleep(2 * time.Second)
 		}
 
 		channel <- nil

--- a/fabric/network.sh
+++ b/fabric/network.sh
@@ -18,7 +18,7 @@ fi
 export FABRIC_CFG_PATH=${PWD}/configtx
 export VERBOSE=false
 # export COMPOSE_PROJECT_NAME=net
-export IMAGE_TAG=2.5.15
+export IMAGE_TAG=2.5.16
 export SYS_CHANNEL=sys-channel
 
 . scripts/utils.sh
@@ -549,7 +549,7 @@ CC_VERSION="0.1"
 # Chaincode definition sequence
 CC_SEQUENCE=1
 # default image tag
-IMAGETAG="2.5.15"
+IMAGETAG="2.5.16"
 # default ca image tag
 CA_IMAGETAG="latest"
 # default database

--- a/fabric/network.sh
+++ b/fabric/network.sh
@@ -18,7 +18,7 @@ fi
 export FABRIC_CFG_PATH=${PWD}/configtx
 export VERBOSE=false
 # export COMPOSE_PROJECT_NAME=net
-export IMAGE_TAG=2.5.3
+export IMAGE_TAG=2.5.15
 export SYS_CHANNEL=sys-channel
 
 . scripts/utils.sh
@@ -549,7 +549,7 @@ CC_VERSION="0.1"
 # Chaincode definition sequence
 CC_SEQUENCE=1
 # default image tag
-IMAGETAG="2.5.3"
+IMAGETAG="2.5.15"
 # default ca image tag
 CA_IMAGETAG="latest"
 # default database

--- a/fabric/startDev.sh
+++ b/fabric/startDev.sh
@@ -42,7 +42,7 @@ download_binaries(){
   curl -sSLO https://raw.githubusercontent.com/hyperledger/fabric/main/scripts/install-fabric.sh && chmod +x install-fabric.sh
 
   echo "Downloading fabric binaries..."
-  ./install-fabric.sh --fabric-version 2.5.3 binary
+  ./install-fabric.sh --fabric-version 2.5.16 binary
 
   rm install-fabric.sh
 }


### PR DESCRIPTION
Update default Fabric image versions to 2.5.16. This fixes the issues regarding chaincode installation on Docker 29